### PR TITLE
Fix situations where `./git/hooks` doesn't exist

### DIFF
--- a/lib/git-scripts.js
+++ b/lib/git-scripts.js
@@ -37,11 +37,15 @@ GitScripts.prototype.install = function(callback) {
         return callback(new Error('Already installed.'));
       }
 
-      fs.rename(self.hooksPath, self.oldHooksPath, function(err) {
+      fs.mkdir(self.hooksPath, function (err) {
         if (err) return callback(err);
 
-        var hooksSrcPath = __dirname + '/../bin/hooks';
-        fs.symlink(path.relative(self.gitPath, hooksSrcPath), self.hooksPath, callback);
+        fs.rename(self.hooksPath, self.oldHooksPath, function(err) {
+          if (err) return callback(err);
+
+          var hooksSrcPath = __dirname + '/../bin/hooks';
+          fs.symlink(path.relative(self.gitPath, hooksSrcPath), self.hooksPath, callback);
+        });
       });
     });
   });


### PR DESCRIPTION
This happens on CircleCI