### PR TITLE
Add support for git submodules

### DIFF
--- a/lib/git-scripts.js
+++ b/lib/git-scripts.js
@@ -166,9 +166,7 @@ GitScripts.prototype.getGitPath = function(pathStr) {
       var gitPathTxt = fs.readFileSync(gitPath, 'utf8');
       gitPath = path.join(pathStr, gitPathTxt.replace('gitdir: ', '')).replace('\n', '');
     }
-
   }
-
   return gitPath;
 };
 

--- a/lib/git-scripts.js
+++ b/lib/git-scripts.js
@@ -7,10 +7,10 @@ var fs = require('fs')
 module.exports = GitScripts;
 
 
-function GitScripts(path) {
-  this.path = path = path || '.';
-  this.packagePath = path + '/package.json';
-  this.gitPath = path + '/.git';
+function GitScripts(pathStr) {
+  this.path = pathStr = pathStr || '.';
+  this.packagePath = pathStr + '/package.json';
+  this.gitPath = this.getGitPath(pathStr);
   this.hooksPath = this.gitPath + '/hooks';
   this.oldHooksPath = this.gitPath + '/hooks.old';
 }
@@ -151,6 +151,25 @@ GitScripts.prototype.readCommand = function(name, callback) {
 
 GitScripts.prototype.isGitRepo = function(callback) {
   fs.exists(this.gitPath, callback);
+};
+
+/**
+ * @api private
+ */
+
+GitScripts.prototype.getGitPath = function(pathStr) {
+  var gitPath = pathStr + '/.git';
+  if (fs.existsSync(gitPath)) {
+    var pathStats = fs.lstatSync(gitPath);
+    // file contains a pointer to the git path
+    if (pathStats.isFile()) {
+      var gitPathTxt = fs.readFileSync(gitPath, 'utf8');
+      gitPath = path.join(pathStr, gitPathTxt.replace('gitdir: ', '')).replace('\n', '');
+    }
+
+  }
+
+  return gitPath;
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -119,12 +119,21 @@ describe('git-scripts', function() {
     beforeEach(function(done) {
       var self = this;
       mktmpdir(function(err, dir) {
-        exec('git init', {cwd: dir});
-        exec('mv .git .git2', {cwd: dir});
-        exec('echo "gitdir: ./.git2" > .git', {cwd: dir}, function(){
+        function setupProj() {
+          exec('git init', {cwd: dir}, moveGitDir);
+        }
+        function moveGitDir() {
+           exec('mv .git .git2', {cwd: dir}, createGitFile);
+        }
+        function createGitFile() {
+          exec('echo "gitdir: ./.git2" > .git', {cwd: dir}, updateProj);
+        }
+        function updateProj() {
           self.proj = scripts(dir);
           done(err);
-        });
+        }
+
+        setupProj();
       });
     });
 


### PR DESCRIPTION
Rather than having a `.git` directory, git submodules have a `.git` file which stores the path to their true `.git` directory, located somewhere in the super-repo.

This enhancement checks to see if `.git` is a file and if so handles it properly, otherwise it defaults to its current behavior.

Includes new tests to cover the expected behavior with submodules.