### PR TITLE
Windows compatibility

### DIFF
--- a/bin/git-scripts
+++ b/bin/git-scripts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-var spawn = require('child_process').spawn
-  , program = require('commander')
+var program = require('commander')
   , pkg = require('../package.json')
   , fs = require('fs');
 
@@ -31,9 +30,5 @@ if (!cmd) {
 
 // execute the subcommand.
 
-var bin = __dirname + '/git-scripts-' + cmd
-  , proc = spawn(bin, args, {stdio: 'inherit', customFds: [0, 1, 2]});
-
-proc.on('close', function(code) {
-  process.exit(code);
-});
+process.argv = args
+require('./git-scripts-' + cmd)

--- a/bin/install
+++ b/bin/install
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 
-var path = require('path')
-  , spawn = require('child_process').spawn;
-
+var path = require('path');
 
 // check if git-scripts is in the `node_modules` directory.
 
@@ -12,12 +10,10 @@ if (path.basename(path.normalize(__dirname + '/../..')) != 'node_modules') {
 
 // execute install on the project root.
 
-var bin = __dirname + '/git-scripts'
-  , args = ['install']
-  , root = __dirname + '/../../..'
-  , proc = spawn(bin, args, {cwd: root, stdio: 'inherit', customFds: [0, 1, 2]});
+var bin = path.join(__dirname, 'git-scripts')
+  , root = path.normalize(__dirname + '/../../..');
 
-proc.on('close', function(code) {
-  process.exit(code);
-});
+process.argv.push('install')
+process.chdir(root);
+require(bin);
 

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "test": "make test",
     "prepublish": "make build",
-    "postinstall": "./bin/install",
-    "postupdate": "./bin/install",
-    "preuninstall": "./bin/uninstall"
+    "postinstall": "node bin/install",
+    "postupdate": "node bin/install",
+    "preuninstall": "node bin/uninstall"
   },
   "bin": {
     "git-scripts": "./bin/git-scripts"


### PR DESCRIPTION
As-is, this package would fail to install on Windows:

```plaintext
'.' is not recognized as an internal or external command,
operable program or batch file.
```

This should solve the issue by basically using requires instead of process spawning. 